### PR TITLE
feat: add hint to REST-API (link to repo and meggsimums swagger export)

### DIFF
--- a/content/_index/cli.md
+++ b/content/_index/cli.md
@@ -1,7 +1,7 @@
 +++
 fragment = "item"
 date = "2020-10-06"
-weight = 120
+weight = 115
 background = "secondary"
 align = "right"
 

--- a/content/_index/docs.md
+++ b/content/_index/docs.md
@@ -6,7 +6,7 @@ background = "secondary"
 align = "right"
 
 title = "GeoStyler: Read the docs"
-subtitle = "Read our API docs for details on how to use the Geostyler React-library to build flexible and powerful GUIs for styling maps in the browser"
+subtitle = "Read our API docs for details on how to use the GeoStyler React-library to build flexible and powerful GUIs for styling maps in the browser"
 
 [[buttons]]
     text = "Read the Docs"

--- a/content/_index/docs.md
+++ b/content/_index/docs.md
@@ -5,8 +5,8 @@ weight = 110
 background = "secondary"
 align = "right"
 
-title = "Geostyler: Read the docs"
-subtitle = "Read our API docs for details on how to use the Geostyler React-library to build flexible and powerfull GUI for styling maps in the browser"
+title = "GeoStyler: Read the docs"
+subtitle = "Read our API docs for details on how to use the Geostyler React-library to build flexible and powerful GUIs for styling maps in the browser"
 
 [[buttons]]
     text = "Read the Docs"

--- a/content/_index/docs.md
+++ b/content/_index/docs.md
@@ -5,7 +5,7 @@ weight = 110
 background = "secondary"
 align = "right"
 
-title = "Geostyler UI: Read the docs"
+title = "Geostyler: Read the docs"
 subtitle = "Read our API docs for details on how to use the Geostyler React-library to build flexible and powerfull GUI for styling maps in the browser"
 
 [[buttons]]

--- a/content/_index/docs.md
+++ b/content/_index/docs.md
@@ -1,19 +1,19 @@
 +++
 fragment = "item"
 date = "2020-10-06"
-weight = 120
-#background = "secondary"
-align = "center"
+weight = 110
+background = "secondary"
+align = "right"
 
-title = "Read the docs"
-subtitle = "Read our API docs for details on code usage."
+title = "Geostyler UI: Read the docs"
+subtitle = "Read our API docs for details on how to use the Geostyler React-library to build flexible and powerfull GUI for styling maps in the browser"
 
 [[buttons]]
     text = "Read the Docs"
     url = "https://geostyler.github.io/geostyler"
 
-#[asset]
-    #icon = "fas fa-book"
+[asset]
+    icon = "fas fa-book"
     #url = "https://geostyler.github.io/geostyler"
 +++
 

--- a/content/_index/formats.md
+++ b/content/_index/formats.md
@@ -2,10 +2,10 @@
 fragment = "item"
 weight = 110
 
-align = "left"
+align = "right"
 title = "Supported Formats"
 subtitle = "Supports SLD, OpenLayers, QML, Mapbox, GeoJSON, WFS, ..."
-background = "secondary"
+#background = "secondary"
 
 [asset]
     icon = "fas fa-check"

--- a/content/_index/osgeo.md
+++ b/content/_index/osgeo.md
@@ -1,7 +1,7 @@
 +++
 fragment = "item"
 date = "2020-10-06"
-weight = 130
+weight = 135
 #background = "secondary"
 align = "left"
 

--- a/content/_index/rest-api.md
+++ b/content/_index/rest-api.md
@@ -1,0 +1,25 @@
++++
+fragment = "item"
+date = "2023-05-11"
+weight = 120
+# background = "secondary"
+align = "right"
+
+title = "GeoStyler Rest API"
+subtitle = "Access Geostyler's style transformation capabilities over the web"
+
+[[buttons]]
+    text = "Checkout the repository"
+    url = "https://github.com/geostyler/geostyler-rest"
+
+[[buttons]]
+    text = "Demo"
+    url = "https://services.meggsimum.de/geostyler-rest/api-docs/"
+
+
+[asset]
+    icon = "fas fa-globe"
+    #url = "https://geostyler.github.io/geostyler"
++++
+
+The Rest-API allows for style conversions using standard HTTP requests.

--- a/content/_index/rest-api.md
+++ b/content/_index/rest-api.md
@@ -6,7 +6,7 @@ weight = 120
 align = "right"
 
 title = "GeoStyler Rest API"
-subtitle = "Access Geostyler's style transformation capabilities over the web"
+subtitle = "Access GeoStyler's style transformation capabilities over the web"
 
 [[buttons]]
     text = "Checkout the repository"


### PR DESCRIPTION
Suggestion for https://github.com/geostyler/geostyler-homepage/issues/2

Changes neighbouring items to ensure alternating backgrounds. 

Also contains an explicit naming for the docs 

changed the order by the weights in a seemingly logical order 

moved osgeo section under tutorials

sorry for the bundled PR


![rest-api-section](https://github.com/geostyler/geostyler-homepage/assets/9952252/3ae74e78-1087-4f10-844a-22de2cf276ae)
